### PR TITLE
Fix deploy: remove .gitkeep before cloning notes repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,9 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v6
-      - name: Fetch research content
+      - name: Fetch notes content
         run: |
+          rm -rf src/content/notes
           git clone --depth 1 https://github.com/eric-minassian/notes.git src/content/notes
           rm -rf src/content/notes/.git
       - name: Install, build, and upload your site


### PR DESCRIPTION
## Summary
- Clears `src/content/notes/` before `git clone` so the `.gitkeep` file doesn't cause a "directory not empty" error

## Test plan
- [ ] Deploy workflow succeeds (clone step no longer fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)