### PR TITLE
Fix mermaid diagram rendering

### DIFF
--- a/src/pages/notes/[slug].astro
+++ b/src/pages/notes/[slug].astro
@@ -38,8 +38,8 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
   </article>
 
   <script is:inline type="module">
-    const codeBlocks = document.querySelectorAll("pre > code.language-mermaid");
-    if (codeBlocks.length > 0) {
+    const pres = document.querySelectorAll('pre[data-language="mermaid"]');
+    if (pres.length > 0) {
       const { default: mermaid } = await import(
         "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs"
       );
@@ -48,11 +48,10 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
         startOnLoad: false,
         theme: isDark ? "dark" : "default",
       });
-      for (const block of codeBlocks) {
-        const pre = block.parentElement;
+      for (const pre of pres) {
         const div = document.createElement("div");
         div.className = "mermaid";
-        div.textContent = block.textContent;
+        div.textContent = pre.textContent;
         pre.replaceWith(div);
       }
       await mermaid.run();


### PR DESCRIPTION
## Summary
- Shiki (Astro's syntax highlighter) renders fenced code blocks as `<pre data-language="mermaid">` not `<pre><code class="language-mermaid">`
- Updated the mermaid script selector from `pre > code.language-mermaid` to `pre[data-language="mermaid"]` to match actual output

## Test plan
- [ ] Verify mermaid diagrams render on https://www.ericminassian.com/notes/upstream-fork-strategy/ after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)