### PR TITLE
Style notes pages with JetBrains Mono and wider layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:visual:update": "playwright test --update-snapshots"
   },
   "dependencies": {
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/newsreader": "^5.2.10"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@fontsource-variable/newsreader':
         specifier: ^5.2.10
         version: 5.2.10
@@ -298,6 +301,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
 
   '@fontsource-variable/newsreader@5.2.10':
     resolution: {integrity: sha512-MdI2iRwrqWpMOU/2aV2BgfZ4dJNlj/XlYaY8Zb7t87mWqHskYW0XiUANkt1cyOCiEfW2VQ0bQ5vZgGPp6B2B4w==}
@@ -2461,6 +2467,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.4':
     optional: true
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@fontsource-variable/newsreader@5.2.10': {}
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,12 +5,14 @@ import "../styles/globals.css";
 
 // Import font files with ?url to get hashed URLs for preloading
 import latinNormal from "@fontsource-variable/newsreader/files/newsreader-latin-wght-normal.woff2?url";
+import jetbrainsMonoLatin from "@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2?url";
 
 interface Props {
   title?: string;
   description?: string;
   type?: "website" | "article";
   noindex?: boolean;
+  wide?: boolean;
 }
 
 const {
@@ -18,6 +20,7 @@ const {
   description = "Software engineer and tech lead at Amazon, working on Leo. Previously led payments software at Walmart. CS + Business from UC Irvine, summa cum laude.",
   type = "website",
   noindex = false,
+  wide = false,
 } = Astro.props;
 
 const siteUrl = "https://www.ericminassian.com";
@@ -88,6 +91,17 @@ const jsonLd = {
       href={latinNormal}
       crossorigin="anonymous"
     />
+    {
+      wide && (
+        <link
+          rel="preload"
+          as="font"
+          type="font/woff2"
+          href={jetbrainsMonoLatin}
+          crossorigin="anonymous"
+        />
+      )
+    }
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="48x32x16" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
@@ -230,7 +244,7 @@ const jsonLd = {
     </script>
   </head>
 
-  <body class="mx-auto max-w-[650px] px-8 py-16">
+  <body class:list={["mx-auto px-8 py-16", wide ? "max-w-[900px]" : "max-w-[650px]"]}>
     <main class="w-full mt-0 md:mt-16">
       <slot />
     </main>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -244,8 +244,8 @@ const jsonLd = {
     </script>
   </head>
 
-  <body class:list={["mx-auto px-8 py-16", wide ? "max-w-[900px]" : "max-w-[650px]"]}>
-    <main class="w-full mt-0 md:mt-16">
+  <body class:list={["mx-auto px-8", wide ? "max-w-[900px] py-8" : "max-w-[650px] py-16"]}>
+    <main class:list={["w-full", wide ? "" : "md:mt-16"]}>
       <slot />
     </main>
     <footer class="mt-16 flex justify-center">

--- a/src/pages/notes/[slug].astro
+++ b/src/pages/notes/[slug].astro
@@ -20,22 +20,24 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
 });
 ---
 
-<Layout title={`${post.data.title} — Eric Minassian`} description={post.data.description} type="article">
-  <nav class="mb-8">
-    <a href="/notes/" class="text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">&larr; Notes</a>
-  </nav>
-  <article>
-    <header class="mb-8">
-      <h1 class="mb-1 text-xl font-medium leading-tight md:text-2xl">{post.data.title}</h1>
-      <p class="text-sm text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
-        <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
-        {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
-      </p>
-    </header>
-    <div class="prose max-w-none dark:prose-invert">
-      <Content />
-    </div>
-  </article>
+<Layout title={`${post.data.title} — Eric Minassian`} description={post.data.description} type="article" wide>
+  <div class="font-mono text-sm leading-relaxed">
+    <nav class="mb-8">
+      <a href="/notes/" class="text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">&larr; Notes</a>
+    </nav>
+    <article>
+      <header class="mb-8">
+        <h1 class="mb-1 text-xl font-semibold leading-tight md:text-2xl">{post.data.title}</h1>
+        <p class="text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+          <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
+          {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
+        </p>
+      </header>
+      <div class="notes-prose prose prose-sm max-w-none dark:prose-invert">
+        <Content />
+      </div>
+    </article>
+  </div>
 
   <script is:inline type="module">
     const pres = document.querySelectorAll('pre[data-language="mermaid"]');
@@ -58,3 +60,61 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
     }
   </script>
 </Layout>
+
+<style>
+  .notes-prose {
+    font-family: var(--font-mono);
+  }
+
+  .notes-prose :global(h1),
+  .notes-prose :global(h2),
+  .notes-prose :global(h3),
+  .notes-prose :global(h4) {
+    font-family: var(--font-mono);
+    font-weight: 600;
+  }
+
+  .notes-prose :global(h2) {
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  :global(.dark) .notes-prose :global(h2) {
+    border-bottom-color: var(--color-border-dark);
+  }
+
+  .notes-prose :global(code:not(pre code)) {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.2em 0.4em;
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, 0.06);
+  }
+
+  :global(.dark) .notes-prose :global(code:not(pre code)) {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .notes-prose :global(pre) {
+    font-family: var(--font-mono);
+    border-radius: 6px;
+    font-size: 0.85em;
+  }
+
+  .notes-prose :global(blockquote) {
+    border-left-width: 4px;
+    font-style: normal;
+  }
+
+  .notes-prose :global(table) {
+    font-size: 0.85em;
+  }
+
+  .notes-prose :global(th) {
+    font-weight: 600;
+  }
+
+  .notes-prose :global(img) {
+    border-radius: 6px;
+  }
+</style>

--- a/src/pages/notes/[slug].astro
+++ b/src/pages/notes/[slug].astro
@@ -22,16 +22,15 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
 
 <Layout title={`${post.data.title} — Eric Minassian`} description={post.data.description} type="article" wide>
   <div class="font-mono text-sm leading-relaxed">
-    <nav class="mb-8">
-      <a href="/notes/" class="text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">&larr; Notes</a>
-    </nav>
     <article>
-      <header class="mb-8">
-        <h1 class="mb-1 text-xl font-semibold leading-tight md:text-2xl">{post.data.title}</h1>
-        <p class="text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+      <header class="mb-6">
+        <nav class="mb-1 flex items-center gap-2 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]" aria-label="Breadcrumb">
+          <a href="/notes/" class="hover:text-[var(--color-text)] dark:hover:text-[var(--color-text-dark)]">notes</a>
+          <span>/</span>
           <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
           {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
-        </p>
+        </nav>
+        <h1 class="text-xl font-semibold leading-tight md:text-2xl">{post.data.title}</h1>
       </header>
       <div class="notes-prose prose prose-sm max-w-none dark:prose-invert">
         <Content />
@@ -39,24 +38,122 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
     </article>
   </div>
 
+  <div id="mermaid-overlay" class="fixed inset-0 z-50 hidden cursor-zoom-out items-center justify-center bg-white dark:bg-neutral-900" role="dialog" aria-modal="true" aria-label="Expanded diagram">
+    <div id="mermaid-overlay-content" class="flex h-full w-full items-center justify-center p-8"></div>
+  </div>
+
   <script is:inline type="module">
-    const pres = document.querySelectorAll('pre[data-language="mermaid"]');
-    if (pres.length > 0) {
-      const { default: mermaid } = await import(
-        "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs"
-      );
-      const isDark = document.documentElement.classList.contains("dark");
-      mermaid.initialize({
-        startOnLoad: false,
-        theme: isDark ? "dark" : "default",
+    const COPY_ICON =
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+    const CHECK_ICON =
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+
+    // Copy buttons — skip mermaid blocks since they get replaced
+    document.querySelectorAll('pre.astro-code:not([data-language="mermaid"])').forEach((pre) => {
+      pre.style.position = "relative";
+      const btn = document.createElement("button");
+      btn.className = "code-copy-btn";
+      btn.setAttribute("aria-label", "Copy code");
+      btn.innerHTML = COPY_ICON;
+      btn.addEventListener("click", async () => {
+        const code = pre.querySelector("code");
+        if (!code) return;
+        try {
+          await navigator.clipboard.writeText(code.textContent ?? "");
+          btn.innerHTML = CHECK_ICON;
+          setTimeout(() => {
+            btn.innerHTML = COPY_ICON;
+          }, 2000);
+        } catch {
+          // Clipboard API unavailable (non-HTTPS, permissions)
+        }
       });
-      for (const pre of pres) {
-        const div = document.createElement("div");
-        div.className = "mermaid";
-        div.textContent = pre.textContent;
-        pre.replaceWith(div);
+      pre.appendChild(btn);
+    });
+
+    // Mermaid rendering
+    const mermaidPres = document.querySelectorAll('pre[data-language="mermaid"]');
+    if (mermaidPres.length > 0) {
+      try {
+        const { default: mermaid } = await import(
+          "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs"
+        );
+        const isDark = document.documentElement.classList.contains("dark");
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: isDark ? "dark" : "default",
+        });
+        for (const pre of mermaidPres) {
+          const wrapper = document.createElement("div");
+          wrapper.className = "mermaid-wrapper";
+          wrapper.setAttribute("role", "button");
+          wrapper.setAttribute("tabindex", "0");
+          wrapper.setAttribute("aria-label", "Click to expand diagram");
+          const div = document.createElement("div");
+          div.className = "mermaid";
+          div.textContent = pre.textContent;
+          wrapper.appendChild(div);
+          pre.replaceWith(wrapper);
+        }
+        await mermaid.run();
+
+        const overlay = document.getElementById("mermaid-overlay");
+        const overlayContent = document.getElementById("mermaid-overlay-content");
+        let lastTrigger = null;
+
+        function openOverlay(wrapper) {
+          const svg = wrapper.querySelector("svg");
+          if (!svg) return;
+          const clone = svg.cloneNode(true);
+          const vb = svg.viewBox.baseVal;
+          const vbW = vb.width || svg.getBoundingClientRect().width;
+          const vbH = vb.height || svg.getBoundingClientRect().height;
+          if (vbW === 0 || vbH === 0) return;
+          const availW = window.innerWidth - 64;
+          const availH = window.innerHeight - 64;
+          const scale = Math.min(availW / vbW, availH / vbH);
+          clone.removeAttribute("width");
+          clone.removeAttribute("height");
+          clone.removeAttribute("style");
+          clone.style.width = vbW * scale + "px";
+          clone.style.height = vbH * scale + "px";
+          overlayContent.replaceChildren(clone);
+          lastTrigger = wrapper;
+          overlay.classList.remove("hidden");
+          overlay.classList.add("flex");
+          overlay.focus();
+        }
+
+        function closeOverlay() {
+          overlay.classList.add("hidden");
+          overlay.classList.remove("flex");
+          overlayContent.replaceChildren();
+          if (lastTrigger) {
+            lastTrigger.focus();
+            lastTrigger = null;
+          }
+        }
+
+        document.querySelectorAll(".mermaid-wrapper").forEach((wrapper) => {
+          wrapper.style.cursor = "zoom-in";
+          wrapper.addEventListener("click", () => openOverlay(wrapper));
+          wrapper.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              openOverlay(wrapper);
+            }
+          });
+        });
+
+        overlay.addEventListener("click", closeOverlay);
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape" && !overlay.classList.contains("hidden")) {
+            closeOverlay();
+          }
+        });
+      } catch (e) {
+        console.warn("Mermaid failed to load:", e);
       }
-      await mermaid.run();
     }
   </script>
 </Layout>
@@ -98,7 +195,31 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
   .notes-prose :global(pre) {
     font-family: var(--font-mono);
     border-radius: 6px;
-    font-size: 0.85em;
+    font-size: 1em;
+  }
+
+  .notes-prose :global(pre:hover .code-copy-btn),
+  .notes-prose :global(pre:focus-within .code-copy-btn) {
+    opacity: 1;
+  }
+
+  :global(.code-copy-btn) {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    padding: 4px;
+    border: none;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.5);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.15s;
+    line-height: 0;
+  }
+
+  :global(.code-copy-btn:hover) {
+    color: rgba(255, 255, 255, 0.9);
   }
 
   .notes-prose :global(blockquote) {

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -8,39 +8,41 @@ const sorted = posts.toSorted(
 );
 ---
 
-<Layout title="Notes — Eric Minassian" description="Notes and explorations on various topics.">
-  <nav class="mb-8">
-    <a href="/" class="text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">&larr; Home</a>
-  </nav>
-  <h1 class="mb-1 text-xl font-medium leading-tight md:text-2xl">Notes</h1>
-  <p class="my-2 text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
-    Notes and explorations on various topics.
-  </p>
-  {
-    sorted.length === 0 ? (
-      <p class="mt-8">Nothing here yet.</p>
-    ) : (
-      <ul class="mt-8 list-none space-y-6 pl-0">
-        {sorted.map((post) => {
-          const formattedDate = post.data.date.toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-          });
-          return (
-            <li>
-              <a href={`/notes/${post.id}/`} class="text-base font-medium no-underline hover:underline">
-                {post.data.title}
-              </a>
-              <p class="mt-0.5 text-sm text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
-                <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
-                {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
-              </p>
-              <p class="mt-1 text-sm">{post.data.description}</p>
-            </li>
-          );
-        })}
-      </ul>
-    )
-  }
+<Layout title="Notes — Eric Minassian" description="Notes and explorations on various topics." wide>
+  <div class="font-mono text-sm leading-relaxed">
+    <nav class="mb-8">
+      <a href="/" class="text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">&larr; Home</a>
+    </nav>
+    <h1 class="mb-1 text-xl font-semibold leading-tight md:text-2xl">Notes</h1>
+    <p class="my-2 text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+      Notes and explorations on various topics.
+    </p>
+    {
+      sorted.length === 0 ? (
+        <p class="mt-8">Nothing here yet.</p>
+      ) : (
+        <ul class="mt-8 list-none space-y-6 pl-0">
+          {sorted.map((post) => {
+            const formattedDate = post.data.date.toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+            });
+            return (
+              <li>
+                <a href={`/notes/${post.id}/`} class="font-semibold no-underline hover:underline">
+                  {post.data.title}
+                </a>
+                <p class="mt-0.5 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+                  <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
+                  {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
+                </p>
+                <p class="mt-1 text-xs">{post.data.description}</p>
+              </li>
+            );
+          })}
+        </ul>
+      )
+    }
+  </div>
 </Layout>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,6 +6,9 @@
 @theme {
   /* Typography */
   --font-serif: "Newsreader Variable", ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono:
+    "JetBrains Mono Variable", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
 
   /* Colors - semantic tokens */
   --color-bg: #f8f5ed;
@@ -26,6 +29,15 @@
     font-style: normal;
     font-display: swap;
     font-weight: 300 800;
+  }
+
+  @font-face {
+    font-family: "JetBrains Mono Variable";
+    src: url("@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2")
+      format("woff2-variations");
+    font-style: normal;
+    font-display: swap;
+    font-weight: 100 800;
   }
 
   html {


### PR DESCRIPTION
## Summary
- JetBrains Mono font for all notes content (monospace, dev-tool feel)
- Wider layout (900px vs 650px) for notes pages via new `wide` prop on Layout
- VS Code markdown preview-inspired prose styling: bordered h2 headings, inline code with subtle backgrounds, smaller base text with relaxed line height
- Font is preloaded only on notes pages to avoid affecting home page perf

## Test plan
- [ ] Verify notes pages render in JetBrains Mono at wider width
- [ ] Verify home page is unaffected (still serif, 650px)
- [ ] Verify dark mode prose styles look correct
- [ ] Check https://www.ericminassian.com/notes/upstream-fork-strategy/ after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)