### PR TITLE
Fix: remove backtick characters from inline code in notes

### DIFF
--- a/src/pages/notes/[slug].astro
+++ b/src/pages/notes/[slug].astro
@@ -188,6 +188,11 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
     background-color: rgba(0, 0, 0, 0.06);
   }
 
+  .notes-prose :global(code:not(pre code))::before,
+  .notes-prose :global(code:not(pre code))::after {
+    content: none;
+  }
+
   :global(.dark) .notes-prose :global(code:not(pre code)) {
     background-color: rgba(255, 255, 255, 0.1);
   }


### PR DESCRIPTION
## Summary
- The `@tailwindcss/typography` plugin adds literal backtick characters around inline `<code>` elements via `::before` and `::after` pseudo-elements
- Override with `content: none` so inline code shows styled but without surrounding backticks

## Test plan
- [ ] Visit any notes page with inline code (e.g. `/notes/upstream-fork-strategy/`)
- [ ] Verify inline code blocks are styled with background/padding but no literal backtick characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)