### PR TITLE
fix: exclude CLAUDE.md/README.md from notes collection

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,7 +3,10 @@ import { z } from "astro/zod";
 import { defineCollection } from "astro:content";
 
 const notes = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./src/content/notes" }),
+  loader: glob({
+    pattern: ["**/*.md", "!**/CLAUDE.md", "!**/README.md"],
+    base: "./src/content/notes",
+  }),
   schema: z.object({
     title: z.string(),
     description: z.string(),


### PR DESCRIPTION
## Summary
- The `Deploy to GitHub Pages` workflow has been failing on `main` since commit `3aec805` ("support different md files") changed the notes glob pattern from `**/index.md` to `**/*.md`.
- The deploy workflow clones notes content from the `eric-minassian/notes` repo, which contains a top-level `CLAUDE.md`. With the broader glob, Astro tries to load it as a note entry — but it has no frontmatter, so the schema validation fails:
  ```
  [InvalidContentEntryDataError] notes → claude data does not match collection schema.
    title: Required
    description: Required
    date: Expected type "date", received "object"
  ```
- This PR keeps the "different md filenames" support but excludes `CLAUDE.md` and `README.md` (any depth) from the notes collection.

## Test plan
- [x] Reproduced locally by adding `src/content/notes/CLAUDE.md` and confirmed `astro check` failed with the same error before the fix.
- [x] `pnpm exec astro check` passes with the fix and the simulated `CLAUDE.md` in place.
- [ ] Confirm the `Deploy to GitHub Pages` workflow succeeds on this branch / after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)