### PR TITLE
feat: expose raw markdown for notes and llms.txt index

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+
+export const GET: APIRoute = async ({ site }) => {
+  const base = site?.toString().replace(/\/$/, "") ?? "";
+  const posts = await getCollection("notes");
+  const sorted = posts.toSorted(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+  );
+
+  const lines = [
+    "# Eric Minassian",
+    "",
+    "> Personal site and notes on various topics.",
+    "",
+    "## Notes",
+    "",
+    ...sorted.map(
+      (post) =>
+        `- [${post.data.title}](${base}/notes/${post.id}.md): ${post.data.description}`,
+    ),
+    "",
+  ];
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -4,9 +4,7 @@ import { getCollection } from "astro:content";
 export const GET: APIRoute = async ({ site }) => {
   const base = site?.toString().replace(/\/$/, "") ?? "";
   const posts = await getCollection("notes");
-  const sorted = posts.toSorted(
-    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-  );
+  const sorted = posts.toSorted((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
   const lines = [
     "# Eric Minassian",
@@ -16,8 +14,7 @@ export const GET: APIRoute = async ({ site }) => {
     "## Notes",
     "",
     ...sorted.map(
-      (post) =>
-        `- [${post.data.title}](${base}/notes/${post.id}.md): ${post.data.description}`,
+      (post) => `- [${post.data.title}](${base}/notes/${post.id}.md): ${post.data.description}`,
     ),
     "",
   ];

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -29,6 +29,8 @@ const formattedDate = post.data.date.toLocaleDateString("en-US", {
           <span>/</span>
           <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
           {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
+          <span> &middot; </span>
+          <a href={`/notes/${post.id}.md`} class="hover:text-[var(--color-text)] dark:hover:text-[var(--color-text-dark)]">view as markdown</a>
         </nav>
         <h1 class="text-xl font-semibold leading-tight md:text-2xl">{post.data.title}</h1>
       </header>

--- a/src/pages/notes/[...slug].md.ts
+++ b/src/pages/notes/[...slug].md.ts
@@ -11,9 +11,7 @@ export async function getStaticPaths() {
 
 export const GET: APIRoute = ({ props }) => {
   const { post } = props;
-  const tags = post.data.tags.length > 0
-    ? `\ntags: [${post.data.tags.join(", ")}]`
-    : "";
+  const tags = post.data.tags.length > 0 ? `\ntags: [${post.data.tags.join(", ")}]` : "";
   const frontmatter = `---
 title: ${JSON.stringify(post.data.title)}
 description: ${JSON.stringify(post.data.description)}

--- a/src/pages/notes/[...slug].md.ts
+++ b/src/pages/notes/[...slug].md.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("notes");
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+export const GET: APIRoute = ({ props }) => {
+  const { post } = props;
+  const tags = post.data.tags.length > 0
+    ? `\ntags: [${post.data.tags.join(", ")}]`
+    : "";
+  const frontmatter = `---
+title: ${JSON.stringify(post.data.title)}
+description: ${JSON.stringify(post.data.description)}
+date: ${post.data.date.toISOString()}${tags}
+---
+
+`;
+  return new Response(frontmatter + (post.body ?? ""), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};


### PR DESCRIPTION
## Summary
- Adds `/notes/<slug>.md` endpoints serving raw markdown with reconstructed frontmatter, so LLMs and tools can fetch any note by appending `.md` to its URL.
- Adds `/llms.txt` at the site root following the [llmstxt.org](https://llmstxt.org) convention — a discoverable index linking every note's `.md` URL.
- Adds a "view as markdown" link to each note's breadcrumb for human discoverability.

## Test plan
- [ ] `pnpm build` produces `notes/<slug>.md` files and `llms.txt` in `dist/`
- [ ] `curl https://www.ericminassian.com/llms.txt` returns the index after deploy
- [ ] `curl https://www.ericminassian.com/notes/<slug>.md` returns raw markdown with frontmatter
- [ ] Visual regression tests pass (breadcrumb adds one link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)