### PR TITLE
feat(notes): add fuzzy search, tree, and graph views

### DIFF
--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -6,6 +6,121 @@ const posts = await getCollection("notes");
 const sorted = posts.toSorted(
   (a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
+
+type NoteNode = {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+  tags: string[];
+  segments: string[];
+};
+
+const nodes: NoteNode[] = posts.map((post) => ({
+  id: post.id,
+  title: post.data.title,
+  description: post.data.description,
+  date: post.data.date.toISOString(),
+  tags: post.data.tags,
+  segments: post.id.split("/"),
+}));
+
+type Edge = { source: string; target: string };
+const edges: Edge[] = [];
+for (let i = 0; i < nodes.length; i++) {
+  for (let j = i + 1; j < nodes.length; j++) {
+    const a = nodes[i];
+    const b = nodes[j];
+    if (a.tags.some((t) => b.tags.includes(t))) {
+      edges.push({ source: a.id, target: b.id });
+    }
+  }
+}
+
+type TreeNode = {
+  name: string;
+  children: Map<string, TreeNode>;
+  note?: NoteNode;
+};
+
+const root: TreeNode = { name: "notes", children: new Map() };
+for (const node of nodes) {
+  const segments = node.segments;
+  const last = segments[segments.length - 1];
+  const folderSegments =
+    last === "index" ? segments.slice(0, -1) : segments.slice(0, -1);
+  let cur = root;
+  for (const seg of folderSegments) {
+    let next = cur.children.get(seg);
+    if (!next) {
+      next = { name: seg, children: new Map() };
+      cur.children.set(seg, next);
+    }
+    cur = next;
+  }
+  if (last === "index") {
+    cur.note = node;
+  } else {
+    let leaf = cur.children.get(last);
+    if (!leaf) {
+      leaf = { name: last, children: new Map() };
+      cur.children.set(last, leaf);
+    }
+    leaf.note = node;
+  }
+}
+
+function renderTree(node: TreeNode, depth = 0): string {
+  const entries = [...node.children.values()].toSorted((a, b) => {
+    const aHas = a.children.size > 0;
+    const bHas = b.children.size > 0;
+    if (aHas !== bHas) return aHas ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  if (entries.length === 0) return "";
+  const items = entries
+    .map((child) => {
+      const isFolder = child.children.size > 0;
+      const note = child.note;
+      const noteIds = collectNoteIds(child);
+      const dataAttr = ` data-note-ids="${noteIds.join(",")}"`;
+      const folderToggle = isFolder
+        ? `<button class="tree-toggle" aria-expanded="true" aria-label="Toggle ${escapeHtml(child.name)}"><span class="tree-caret">▾</span></button>`
+        : `<span class="tree-bullet">•</span>`;
+      const label = note
+        ? `<a href="/notes/${note.id}/" class="tree-link">${escapeHtml(note.title)}</a>`
+        : `<span class="tree-folder">${escapeHtml(child.name)}</span>`;
+      const meta = note
+        ? ` <span class="tree-meta">${escapeHtml(note.tags.join(", "))}</span>`
+        : "";
+      const childHtml = isFolder
+        ? `<div class="tree-children">${renderTree(child, depth + 1)}</div>`
+        : "";
+      return `<li class="tree-item"${dataAttr}><div class="tree-row">${folderToggle}${label}${meta}</div>${childHtml}</li>`;
+    })
+    .join("");
+  return `<ul class="tree-list">${items}</ul>`;
+}
+
+function collectNoteIds(node: TreeNode): string[] {
+  const ids: string[] = [];
+  if (node.note) ids.push(node.note.id);
+  for (const child of node.children.values()) {
+    ids.push(...collectNoteIds(child));
+  }
+  return ids;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const treeHtml = renderTree(root);
+const graphData = { nodes, edges };
 ---
 
 <Layout title="Notes — Eric Minassian" description="Notes and explorations on various topics." wide>
@@ -17,32 +132,408 @@ const sorted = posts.toSorted(
     <p class="my-2 text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
       Notes and explorations on various topics.
     </p>
+
     {
       sorted.length === 0 ? (
         <p class="mt-8">Nothing here yet.</p>
       ) : (
-        <ul class="mt-8 list-none space-y-6 pl-0">
-          {sorted.map((post) => {
-            const formattedDate = post.data.date.toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "short",
-              day: "numeric",
-            });
-            return (
-              <li>
-                <a href={`/notes/${post.id}/`} class="font-semibold no-underline hover:underline">
-                  {post.data.title}
-                </a>
-                <p class="mt-0.5 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
-                  <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
-                  {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
-                </p>
-                <p class="mt-1 text-xs">{post.data.description}</p>
-              </li>
-            );
-          })}
-        </ul>
+        <div class="mt-6">
+          <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <input
+              type="search"
+              id="notes-search"
+              placeholder="Search notes…"
+              aria-label="Search notes"
+              class="w-full rounded border border-[var(--color-border)] bg-transparent px-3 py-1.5 text-sm font-mono outline-none focus:border-[var(--color-text)] sm:max-w-xs dark:border-[var(--color-border-dark)] dark:focus:border-[var(--color-text-dark)]"
+            />
+            <div class="flex gap-1 text-xs" role="tablist" aria-label="View mode">
+              <button data-view="list" class="view-btn is-active" role="tab" aria-selected="true">list</button>
+              <button data-view="tree" class="view-btn" role="tab" aria-selected="false">tree</button>
+              <button data-view="graph" class="view-btn" role="tab" aria-selected="false">graph</button>
+            </div>
+          </div>
+
+          <p id="notes-empty" class="my-8 hidden text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+            No notes match your search.
+          </p>
+
+          <div data-view-panel="list">
+            <ul class="list-none space-y-6 pl-0">
+              {sorted.map((post) => {
+                const formattedDate = post.data.date.toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                });
+                const haystack = [
+                  post.data.title,
+                  post.data.description,
+                  post.data.tags.join(" "),
+                  post.id,
+                ]
+                  .join(" ")
+                  .toLowerCase();
+                return (
+                  <li class="note-item" data-note-id={post.id} data-haystack={haystack}>
+                    <a href={`/notes/${post.id}/`} class="font-semibold no-underline hover:underline">
+                      {post.data.title}
+                    </a>
+                    <p class="mt-0.5 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+                      <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
+                      {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
+                    </p>
+                    <p class="mt-1 text-xs">{post.data.description}</p>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          <div data-view-panel="tree" class="hidden" set:html={treeHtml} />
+
+          <div data-view-panel="graph" class="hidden">
+            <div class="relative h-[500px] w-full overflow-hidden rounded border border-[var(--color-border)] dark:border-[var(--color-border-dark)]">
+              <svg id="notes-graph" class="h-full w-full" aria-label="Note connections graph"></svg>
+              <p id="notes-graph-loading" class="absolute inset-0 flex items-center justify-center text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+                Loading graph…
+              </p>
+            </div>
+            <p class="mt-2 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+              Nodes are notes; edges connect notes that share at least one tag.
+            </p>
+          </div>
+        </div>
       )
     }
   </div>
+
+  <script is:inline type="application/json" id="notes-graph-data" set:html={JSON.stringify(graphData)} />
+
+  <script is:inline type="module">
+    function fuzzyMatch(needle, haystack) {
+      if (!needle) return true;
+      needle = needle.toLowerCase().trim();
+      if (!needle) return true;
+      if (haystack.includes(needle)) return true;
+      let i = 0;
+      for (let k = 0; k < haystack.length && i < needle.length; k++) {
+        if (haystack[k] === needle[i]) i++;
+      }
+      return i === needle.length;
+    }
+
+    const dataEl = document.getElementById("notes-graph-data");
+    if (dataEl) {
+      const { nodes, edges } = JSON.parse(dataEl.textContent || "{}");
+      const search = document.getElementById("notes-search");
+      const empty = document.getElementById("notes-empty");
+      const viewBtns = document.querySelectorAll(".view-btn");
+      const panels = document.querySelectorAll("[data-view-panel]");
+
+      const noteHaystacks = new Map();
+      for (const n of nodes) {
+        noteHaystacks.set(
+          n.id,
+          [n.title, n.description, n.tags.join(" "), n.id].join(" ").toLowerCase(),
+        );
+      }
+
+      let matchedIds = new Set(nodes.map((n) => n.id));
+      let currentView = "list";
+
+      function applyFilter(query) {
+        matchedIds = new Set();
+        for (const [id, hay] of noteHaystacks) {
+          if (fuzzyMatch(query, hay)) matchedIds.add(id);
+        }
+
+        // List
+        for (const li of document.querySelectorAll(".note-item")) {
+          const id = li.getAttribute("data-note-id");
+          li.classList.toggle("hidden", !matchedIds.has(id));
+        }
+
+        // Tree: hide a tree-item if none of its descendant notes match
+        for (const li of document.querySelectorAll(".tree-item")) {
+          const ids = (li.getAttribute("data-note-ids") || "").split(",").filter(Boolean);
+          const visible = ids.some((id) => matchedIds.has(id));
+          li.classList.toggle("hidden", !visible);
+        }
+
+        empty.classList.toggle("hidden", matchedIds.size > 0);
+
+        if (currentView === "graph") renderGraph();
+      }
+
+      search?.addEventListener("input", (e) => applyFilter(e.target.value));
+
+      // Tree toggle
+      document.addEventListener("click", (e) => {
+        const btn = e.target.closest(".tree-toggle");
+        if (!btn) return;
+        const li = btn.closest(".tree-item");
+        const children = li?.querySelector(":scope > .tree-children");
+        if (!children) return;
+        const open = btn.getAttribute("aria-expanded") === "true";
+        btn.setAttribute("aria-expanded", String(!open));
+        children.classList.toggle("hidden", open);
+        btn.querySelector(".tree-caret").textContent = open ? "▸" : "▾";
+      });
+
+      // View toggle
+      let d3Promise = null;
+      function loadD3() {
+        if (!d3Promise) {
+          d3Promise = import("https://cdn.jsdelivr.net/npm/d3@7/+esm");
+        }
+        return d3Promise;
+      }
+
+      let simulation = null;
+      let graphReady = false;
+
+      async function renderGraph() {
+        const svg = document.getElementById("notes-graph");
+        const loading = document.getElementById("notes-graph-loading");
+        if (!svg) return;
+        let d3;
+        try {
+          d3 = await loadD3();
+        } catch {
+          loading.textContent = "Could not load graph library.";
+          return;
+        }
+
+        const visibleNodes = nodes
+          .filter((n) => matchedIds.has(n.id))
+          .map((n) => ({ ...n }));
+        const visibleIds = new Set(visibleNodes.map((n) => n.id));
+        const visibleEdges = edges
+          .filter((e) => visibleIds.has(e.source) && visibleIds.has(e.target))
+          .map((e) => ({ ...e }));
+
+        const rect = svg.getBoundingClientRect();
+        const width = rect.width || 800;
+        const height = rect.height || 500;
+
+        const isDark = document.documentElement.classList.contains("dark");
+        const linkColor = isDark ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.18)";
+        const nodeColor = isDark ? "#e5e5e5" : "#262626";
+        const labelColor = isDark ? "rgba(229,229,229,0.7)" : "rgba(38,38,38,0.7)";
+
+        const d3svg = d3.select(svg);
+        d3svg.selectAll("*").remove();
+        d3svg.attr("viewBox", `0 0 ${width} ${height}`);
+
+        const container = d3svg.append("g");
+
+        d3svg.call(
+          d3
+            .zoom()
+            .scaleExtent([0.3, 4])
+            .on("zoom", (event) => container.attr("transform", event.transform)),
+        );
+
+        const link = container
+          .append("g")
+          .attr("stroke", linkColor)
+          .attr("stroke-width", 1)
+          .selectAll("line")
+          .data(visibleEdges)
+          .join("line");
+
+        const node = container
+          .append("g")
+          .selectAll("g")
+          .data(visibleNodes)
+          .join("g")
+          .attr("cursor", "pointer")
+          .on("click", (_event, d) => {
+            window.location.href = `/notes/${d.id}/`;
+          });
+
+        node
+          .append("circle")
+          .attr("r", 5)
+          .attr("fill", nodeColor);
+
+        node
+          .append("text")
+          .text((d) => d.title)
+          .attr("x", 8)
+          .attr("y", 4)
+          .attr("font-size", "11px")
+          .attr("font-family", "var(--font-mono)")
+          .attr("fill", labelColor);
+
+        if (simulation) simulation.stop();
+        simulation = d3
+          .forceSimulation(visibleNodes)
+          .force(
+            "link",
+            d3
+              .forceLink(visibleEdges)
+              .id((d) => d.id)
+              .distance(80),
+          )
+          .force("charge", d3.forceManyBody().strength(-180))
+          .force("center", d3.forceCenter(width / 2, height / 2))
+          .force("collide", d3.forceCollide(24))
+          .on("tick", () => {
+            link
+              .attr("x1", (d) => d.source.x)
+              .attr("y1", (d) => d.source.y)
+              .attr("x2", (d) => d.target.x)
+              .attr("y2", (d) => d.target.y);
+            node.attr("transform", (d) => `translate(${d.x},${d.y})`);
+          });
+
+        const drag = d3
+          .drag()
+          .on("start", (event, d) => {
+            if (!event.active) simulation.alphaTarget(0.3).restart();
+            d.fx = d.x;
+            d.fy = d.y;
+          })
+          .on("drag", (event, d) => {
+            d.fx = event.x;
+            d.fy = event.y;
+          })
+          .on("end", (event, d) => {
+            if (!event.active) simulation.alphaTarget(0);
+            d.fx = null;
+            d.fy = null;
+          });
+
+        node.call(drag);
+
+        loading.classList.add("hidden");
+        graphReady = true;
+      }
+
+      for (const btn of viewBtns) {
+        btn.addEventListener("click", () => {
+          const view = btn.getAttribute("data-view");
+          currentView = view;
+          for (const b of viewBtns) {
+            const active = b === btn;
+            b.classList.toggle("is-active", active);
+            b.setAttribute("aria-selected", String(active));
+          }
+          for (const p of panels) {
+            p.classList.toggle("hidden", p.getAttribute("data-view-panel") !== view);
+          }
+          if (view === "graph" && !graphReady) {
+            renderGraph();
+          }
+        });
+      }
+    }
+  </script>
+
+  <style>
+    .view-btn {
+      padding: 4px 10px;
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      background: transparent;
+      color: var(--color-muted);
+      cursor: pointer;
+      font-family: var(--font-mono);
+      transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+    }
+    :global(.dark) .view-btn {
+      border-color: var(--color-border-dark);
+      color: var(--color-muted-dark);
+    }
+    .view-btn:hover {
+      color: var(--color-text);
+    }
+    :global(.dark) .view-btn:hover {
+      color: var(--color-text-dark);
+    }
+    .view-btn.is-active {
+      color: var(--color-text);
+      border-color: var(--color-text);
+    }
+    :global(.dark) .view-btn.is-active {
+      color: var(--color-text-dark);
+      border-color: var(--color-text-dark);
+    }
+
+    :global(.tree-list) {
+      list-style: none;
+      padding-left: 0;
+      margin: 0;
+    }
+    :global(.tree-list .tree-list) {
+      padding-left: 1.25rem;
+      border-left: 1px dashed var(--color-border);
+      margin-left: 0.5rem;
+    }
+    :global(.dark .tree-list .tree-list) {
+      border-left-color: var(--color-border-dark);
+    }
+    :global(.tree-item) {
+      margin: 0.25rem 0;
+    }
+    :global(.tree-row) {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    :global(.tree-toggle) {
+      background: transparent;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+      color: var(--color-muted);
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      width: 1rem;
+      text-align: center;
+    }
+    :global(.dark .tree-toggle) {
+      color: var(--color-muted-dark);
+    }
+    :global(.tree-caret) {
+      display: inline-block;
+    }
+    :global(.tree-bullet) {
+      color: var(--color-muted);
+      width: 1rem;
+      text-align: center;
+      font-size: 0.75rem;
+    }
+    :global(.dark .tree-bullet) {
+      color: var(--color-muted-dark);
+    }
+    :global(.tree-folder) {
+      font-weight: 600;
+    }
+    :global(.tree-link) {
+      text-decoration: none;
+    }
+    :global(.tree-link:hover) {
+      text-decoration: underline;
+    }
+    :global(.tree-meta) {
+      font-size: 0.7rem;
+      color: var(--color-muted);
+    }
+    :global(.dark .tree-meta) {
+      color: var(--color-muted-dark);
+    }
+
+    #notes-graph text {
+      pointer-events: none;
+      user-select: none;
+    }
+
+    #notes-search::-webkit-search-cancel-button,
+    #notes-search::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+    }
+  </style>
 </Layout>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -207,7 +207,7 @@ const graphData = { nodes, edges };
     }
   </div>
 
-  <script is:inline type="application/json" id="notes-graph-data" set:html={JSON.stringify(graphData)} />
+  <script is:inline type="application/json" id="notes-graph-data" set:html={JSON.stringify(graphData)}></script>
 
   <script is:inline type="module">
     function fuzzyMatch(needle, haystack) {


### PR DESCRIPTION
## Summary
- Adds three view modes to `/notes`: **list** (existing), **tree** (folder hierarchy derived from file paths, with collapsible folders and `index.md` flattening into its parent name), and **graph** (force-directed, d3-force lazy-loaded from jsdelivr — same CDN pattern used for mermaid in `[...slug].astro`).
- Adds a fuzzy search input that filters all three views simultaneously via subsequence match across title, description, tags, and path.
- Graph edges connect any two notes that share at least one tag. Nodes are draggable, the view zooms/pans, and clicking a node opens the note.
- Hides the webkit native `<input type=search>` clear X for visual consistency with the mono aesthetic.

## Test plan
- [ ] `pnpm dev` and visit `/notes`; default view is list and matches the previous styling.
- [ ] Toggle to **tree** — confirm `example-topic/index.md` shows as a leaf with its title (not as a folder wrapping `index`).
- [ ] Toggle to **graph** — confirm d3 loads, nodes render, drag/zoom work, clicking a node navigates to the note.
- [ ] Type in the search input — confirm list items, tree items, and graph nodes filter together; clearing the input restores everything.
- [ ] Empty-state copy ("No notes match your search.") appears when search matches nothing.
- [ ] Light and dark themes both render reasonably (graph link/label colors flip with theme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)