### PR TITLE
fix: lint and format on main

### DIFF
--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -1,9 +1,6 @@
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import { chromium } from "@playwright/test";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const html = `<!DOCTYPE html>
 <html>
@@ -57,7 +54,7 @@ async function main() {
   await page.setContent(html, { waitUntil: "networkidle" });
   await page.evaluate(() => document.fonts.ready);
   await page.screenshot({
-    path: join(__dirname, "..", "public", "og-image.png"),
+    path: join(import.meta.dirname, "..", "public", "og-image.png"),
     type: "png",
   });
   await browser.close();

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,7 +4,7 @@ import { defineCollection } from "astro:content";
 
 const notes = defineCollection({
   loader: glob({
-    pattern: ["**/*.md", "!**/CLAUDE.md", "!**/AGENTS.md",  "!**/README.md"],
+    pattern: ["**/*.md", "!**/CLAUDE.md", "!**/AGENTS.md", "!**/README.md"],
     base: "./src/content/notes",
   }),
   schema: z.object({


### PR DESCRIPTION
## Summary
- Fix double-space formatting in `src/content.config.ts` glob pattern.
- Replace dangling `__dirname` in `scripts/generate-og.mjs` with `import.meta.dirname` to clear oxlint warning.

## Test plan
- [x] `pnpm fmt:check` passes
- [x] `pnpm lint` reports 0 warnings, 0 errors