### PR TITLE
ci(lighthouse): capture reports and log perf diagnostics

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -32,3 +32,11 @@ jobs:
 
       - name: Run Lighthouse
         run: pnpm test:lighthouse
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-reports
+          path: lighthouse-reports/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ src/content/notes/*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# lighthouse
+/lighthouse-reports/
+/tmp-lighthouse-*.json

--- a/scripts/run-lighthouse.mjs
+++ b/scripts/run-lighthouse.mjs
@@ -1,12 +1,28 @@
 import { spawn } from "node:child_process";
 import { createReadStream } from "node:fs";
-import { readFile, stat } from "node:fs/promises";
+import { mkdir, readFile, stat } from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
 
 const DIST_DIR = path.resolve("dist");
+const REPORT_DIR = path.resolve("lighthouse-reports");
 const LIGHTHOUSE_FLAGS = ["--headless=new", "--no-sandbox"];
 const REQUIRED_SCORE = 1;
+const PERF_DIAGNOSTIC_AUDITS = [
+  "first-contentful-paint",
+  "largest-contentful-paint",
+  "speed-index",
+  "total-blocking-time",
+  "cumulative-layout-shift",
+  "interactive",
+  "max-potential-fid",
+  "server-response-time",
+  "render-blocking-resources",
+  "unused-javascript",
+  "unused-css-rules",
+  "uses-text-compression",
+  "uses-responsive-images",
+];
 
 const MIME_TYPES = {
   ".css": "text/css; charset=utf-8",
@@ -134,8 +150,42 @@ async function startStaticServer() {
   };
 }
 
+function formatAudit(audit) {
+  const score = audit.score === null ? "n/a" : audit.score.toFixed(2);
+  const value = audit.displayValue ? ` (${audit.displayValue})` : "";
+  return `    - ${audit.id}: score=${score}${value}`;
+}
+
+function logPerformanceDiagnostics(name, report) {
+  const audits = report.audits ?? {};
+  const lines = [];
+
+  lines.push(`  ${name} performance audits:`);
+  for (const id of PERF_DIAGNOSTIC_AUDITS) {
+    const audit = audits[id];
+    if (audit) {
+      lines.push(formatAudit(audit));
+    }
+  }
+
+  const failing = Object.values(audits).filter(
+    (audit) =>
+      typeof audit.score === "number" &&
+      audit.score < 1 &&
+      !PERF_DIAGNOSTIC_AUDITS.includes(audit.id),
+  );
+  if (failing.length > 0) {
+    lines.push(`  other audits with score < 1:`);
+    for (const audit of failing) {
+      lines.push(formatAudit(audit));
+    }
+  }
+
+  console.log(lines.join("\n"));
+}
+
 async function runSingleLighthouse(baseUrl, { name, extraArgs }) {
-  const outputPath = `./tmp-lighthouse-${name}.json`;
+  const outputPath = path.join(REPORT_DIR, name);
 
   await run("npx", [
     "--yes",
@@ -144,11 +194,12 @@ async function runSingleLighthouse(baseUrl, { name, extraArgs }) {
     "--quiet",
     `--output-path=${outputPath}`,
     "--output=json",
+    "--output=html",
     `--chrome-flags=${LIGHTHOUSE_FLAGS.join(" ")}`,
     ...extraArgs,
   ]);
 
-  const report = JSON.parse(await readFile(outputPath, "utf8"));
+  const report = JSON.parse(await readFile(`${outputPath}.report.json`, "utf8"));
   const categories = report.categories;
   const scores = {
     performance: categories.performance.score,
@@ -157,26 +208,39 @@ async function runSingleLighthouse(baseUrl, { name, extraArgs }) {
     seo: categories.seo.score,
   };
 
-  for (const [category, score] of Object.entries(scores)) {
-    if (score < REQUIRED_SCORE) {
-      throw new Error(
-        `${name} ${category} score was ${roundedScore(score)}; required ${roundedScore(REQUIRED_SCORE)}`,
-      );
-    }
-  }
-
   console.log(
     `${name}:`,
     Object.entries(scores)
       .map(([category, score]) => `${category}=${roundedScore(score)}`)
       .join(" "),
   );
+
+  for (const [category, score] of Object.entries(scores)) {
+    if (score < REQUIRED_SCORE) {
+      if (category === "performance") {
+        logPerformanceDiagnostics(name, report);
+      }
+      throw new Error(
+        `${name} ${category} score was ${roundedScore(score)}; required ${roundedScore(REQUIRED_SCORE)}`,
+      );
+    }
+  }
 }
 
+await mkdir(REPORT_DIR, { recursive: true });
 const server = await startStaticServer();
 
 try {
-  await Promise.all(runs.map((runConfig) => runSingleLighthouse(server.url, runConfig)));
+  const results = await Promise.allSettled(
+    runs.map((runConfig) => runSingleLighthouse(server.url, runConfig)),
+  );
+  const failures = results.filter((result) => result.status === "rejected");
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(failure.reason);
+    }
+    throw new Error(`${failures.length} lighthouse run(s) failed`);
+  }
 } finally {
   await server.close();
 }


### PR DESCRIPTION
## Summary
- Write Lighthouse JSON + HTML reports to `lighthouse-reports/` and upload as a workflow artifact on every run (`if: always()`), so a flake can be inspected without re-running CI.
- On a `performance` category failure, dump the headline audits (FCP, LCP, Speed Index, TBT, CLS, TTI, server-response-time, render-blocking-resources, unused JS/CSS, etc.) plus any other audit with score < 1 — visible directly in the job log.
- Switch the two runs from `Promise.all` to `Promise.allSettled` so a mobile failure no longer aborts the desktop run; both reports are always produced.
- Gitignore the new local report dir.

## Why
Mobile perf is flapping between 94 and 100 in CI (`ignore AGENTS` push: 98; `fix-lint-format` PR: 94) while desktop sits at 100. We need to see which audit is the culprit before deciding whether the bar is wrong or the site is.

## Test plan
- [ ] Trigger this PR's Lighthouse run; on failure, the job log shows the audit breakdown and the artifact `lighthouse-reports` contains both `mobile.report.html` and `desktop.report.html`.
- [ ] On a passing run, the artifact is still uploaded with both HTML reports.