### PR TITLE
feat(notes): make frontmatter optional, derive title from filename

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,15 +2,25 @@ import { glob } from "astro/loaders";
 import { z } from "astro/zod";
 import { defineCollection } from "astro:content";
 
+const optionalDate = z.preprocess((val) => {
+  if (val === undefined || val === null || val === "") return undefined;
+  if (val instanceof Date) return val;
+  if (typeof val === "string" || typeof val === "number") {
+    const d = new Date(val);
+    return Number.isNaN(d.getTime()) ? undefined : d;
+  }
+  return undefined;
+}, z.date().optional());
+
 const notes = defineCollection({
   loader: glob({
     pattern: ["**/*.md", "!**/CLAUDE.md", "!**/AGENTS.md", "!**/README.md"],
     base: "./src/content/notes",
   }),
   schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    date: z.coerce.date(),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    date: optionalDate,
     tags: z.array(z.string()).default([]),
   }),
 });

--- a/src/lib/notes.ts
+++ b/src/lib/notes.ts
@@ -1,0 +1,27 @@
+import type { CollectionEntry } from "astro:content";
+
+export type NormalizedNote = {
+  id: string;
+  title: string;
+  description: string;
+  date: Date | null;
+  tags: string[];
+};
+
+export function titleFromId(id: string): string {
+  const segments = id.split("/");
+  const last = segments[segments.length - 1] ?? id;
+  const base =
+    last === "index" && segments.length > 1 ? (segments[segments.length - 2] ?? last) : last;
+  return base.replaceAll(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function normalizeNote(post: CollectionEntry<"notes">): NormalizedNote {
+  return {
+    id: post.id,
+    title: post.data.title ?? titleFromId(post.id),
+    description: post.data.description ?? "",
+    date: post.data.date ?? null,
+    tags: post.data.tags,
+  };
+}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,10 +1,16 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 
+import { normalizeNote } from "../lib/notes";
+
 export const GET: APIRoute = async ({ site }) => {
   const base = site?.toString().replace(/\/$/, "") ?? "";
   const posts = await getCollection("notes");
-  const sorted = posts.toSorted((a, b) => b.data.date.getTime() - a.data.date.getTime());
+  const sorted = posts
+    .map(normalizeNote)
+    .toSorted(
+      (a, b) => (b.date ? b.date.getTime() : -Infinity) - (a.date ? a.date.getTime() : -Infinity),
+    );
 
   const lines = [
     "# Eric Minassian",
@@ -14,7 +20,8 @@ export const GET: APIRoute = async ({ site }) => {
     "## Notes",
     "",
     ...sorted.map(
-      (post) => `- [${post.data.title}](${base}/notes/${post.id}.md): ${post.data.description}`,
+      (note) =>
+        `- [${note.title}](${base}/notes/${note.id}.md)${note.description ? `: ${note.description}` : ""}`,
     ),
     "",
   ];

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { getCollection, render } from "astro:content";
+import { normalizeNote } from "../../lib/notes";
 
 export async function getStaticPaths() {
   const posts = await getCollection("notes");
@@ -12,27 +13,32 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+const note = normalizeNote(post);
 
-const formattedDate = post.data.date.toLocaleDateString("en-US", {
+const formattedDate = note.date?.toLocaleDateString("en-US", {
   year: "numeric",
   month: "long",
   day: "numeric",
 });
 ---
 
-<Layout title={`${post.data.title} — Eric Minassian`} description={post.data.description} type="article" wide>
+<Layout title={`${note.title} — Eric Minassian`} description={note.description} type="article" wide>
   <div class="font-mono text-sm leading-relaxed">
     <article>
       <header class="mb-6">
         <nav class="mb-1 flex items-center gap-2 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]" aria-label="Breadcrumb">
           <a href="/notes/" class="hover:text-[var(--color-text)] dark:hover:text-[var(--color-text-dark)]">notes</a>
           <span>/</span>
-          <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
-          {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
-          <span> &middot; </span>
+          {note.date && formattedDate && (
+            <>
+              <time datetime={note.date.toISOString()}>{formattedDate}</time>
+              <span> &middot; </span>
+            </>
+          )}
+          {note.tags.length > 0 && <><span>{note.tags.join(", ")}</span><span> &middot; </span></>}
           <a href={`/notes/${post.id}.md`} class="hover:text-[var(--color-text)] dark:hover:text-[var(--color-text-dark)]">view as markdown</a>
         </nav>
-        <h1 class="text-xl font-semibold leading-tight md:text-2xl">{post.data.title}</h1>
+        <h1 class="text-xl font-semibold leading-tight md:text-2xl">{note.title}</h1>
       </header>
       <div class="notes-prose prose prose-sm max-w-none dark:prose-invert">
         <Content />

--- a/src/pages/notes/[...slug].md.ts
+++ b/src/pages/notes/[...slug].md.ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 
+import { normalizeNote } from "../../lib/notes";
+
 export async function getStaticPaths() {
   const posts = await getCollection("notes");
   return posts.map((post) => ({
@@ -11,14 +13,14 @@ export async function getStaticPaths() {
 
 export const GET: APIRoute = ({ props }) => {
   const { post } = props;
-  const tags = post.data.tags.length > 0 ? `\ntags: [${post.data.tags.join(", ")}]` : "";
-  const frontmatter = `---
-title: ${JSON.stringify(post.data.title)}
-description: ${JSON.stringify(post.data.description)}
-date: ${post.data.date.toISOString()}${tags}
----
-
-`;
+  const note = normalizeNote(post);
+  const lines = [
+    `title: ${JSON.stringify(note.title)}`,
+    `description: ${JSON.stringify(note.description)}`,
+  ];
+  if (note.date) lines.push(`date: ${note.date.toISOString()}`);
+  if (note.tags.length > 0) lines.push(`tags: [${note.tags.join(", ")}]`);
+  const frontmatter = `---\n${lines.join("\n")}\n---\n\n`;
   return new Response(frontmatter + (post.body ?? ""), {
     headers: { "Content-Type": "text/markdown; charset=utf-8" },
   });

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -1,28 +1,33 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { getCollection } from "astro:content";
+import { normalizeNote, type NormalizedNote } from "../../lib/notes";
 
 const posts = await getCollection("notes");
-const sorted = posts.toSorted(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-);
+const normalized = posts.map(normalizeNote);
+
+function dateMs(note: NormalizedNote): number {
+  return note.date ? note.date.getTime() : -Infinity;
+}
+
+const sorted = normalized.toSorted((a, b) => dateMs(b) - dateMs(a));
 
 type NoteNode = {
   id: string;
   title: string;
   description: string;
-  date: string;
+  date: string | null;
   tags: string[];
   segments: string[];
 };
 
-const nodes: NoteNode[] = posts.map((post) => ({
-  id: post.id,
-  title: post.data.title,
-  description: post.data.description,
-  date: post.data.date.toISOString(),
-  tags: post.data.tags,
-  segments: post.id.split("/"),
+const nodes: NoteNode[] = normalized.map((note) => ({
+  id: note.id,
+  title: note.title,
+  description: note.description,
+  date: note.date ? note.date.toISOString() : null,
+  tags: note.tags,
+  segments: note.id.split("/"),
 }));
 
 type Edge = { source: string; target: string };
@@ -165,30 +170,35 @@ const graphData = { nodes, edges };
 
           <div data-view-panel="list">
             <ul class="list-none space-y-6 pl-0">
-              {sorted.map((post) => {
-                const formattedDate = post.data.date.toLocaleDateString("en-US", {
+              {sorted.map((note) => {
+                const formattedDate = note.date?.toLocaleDateString("en-US", {
                   year: "numeric",
                   month: "short",
                   day: "numeric",
                 });
                 const haystack = [
-                  post.data.title,
-                  post.data.description,
-                  post.data.tags.join(" "),
-                  post.id,
+                  note.title,
+                  note.description,
+                  note.tags.join(" "),
+                  note.id,
                 ]
                   .join(" ")
                   .toLowerCase();
                 return (
-                  <li class="note-item" data-note-id={post.id} data-haystack={haystack} data-date={post.data.date.getTime()}>
-                    <a href={`/notes/${post.id}/`} class="font-semibold no-underline hover:underline">
-                      {post.data.title}
+                  <li class="note-item" data-note-id={note.id} data-haystack={haystack} data-date={dateMs(note)}>
+                    <a href={`/notes/${note.id}/`} class="font-semibold no-underline hover:underline">
+                      {note.title}
                     </a>
-                    <p class="mt-0.5 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
-                      <time datetime={post.data.date.toISOString()}>{formattedDate}</time>
-                      {post.data.tags.length > 0 && <span> &middot; {post.data.tags.join(", ")}</span>}
-                    </p>
-                    <p class="mt-1 text-xs">{post.data.description}</p>
+                    {(note.date || note.tags.length > 0) && (
+                      <p class="mt-0.5 text-xs text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]">
+                        {note.date && formattedDate && (
+                          <time datetime={note.date.toISOString()}>{formattedDate}</time>
+                        )}
+                        {note.date && note.tags.length > 0 && <span> &middot; </span>}
+                        {note.tags.length > 0 && <span>{note.tags.join(", ")}</span>}
+                      </p>
+                    )}
+                    {note.description && <p class="mt-1 text-xs">{note.description}</p>}
                   </li>
                 );
               })}


### PR DESCRIPTION
## Summary
- Notes without (or with partial) frontmatter no longer fail the content collection schema — `title`, `description`, and `date` are all optional, and `date` is preprocessed to safely ignore invalid/empty values.
- Missing titles fall back to a titlecased version of the filename (e.g. `ai-chat/DESIGN.md` → "Design", `foo/index.md` → "Foo") via a new `src/lib/notes.ts` helper (`normalizeNote` / `titleFromId`).
- List, tree, graph, markdown export, and `llms.txt` views all skip date/description/tag chrome when those fields are absent; date-less notes sort to the bottom in newest-first order.
- Fixes the failed build at https://github.com/eric-minassian/website/actions/runs/25979655347.

## Test plan
- [x] \`pnpm exec astro check\` — 0 errors
- [x] \`pnpm run lint\` — no new warnings
- [x] \`pnpm run fmt:check\`
- [ ] Verify notes list/tree/graph render correctly for a note with no frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)