### PR TITLE
feat(auth): integrate auth.ericminassian.com SSO

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,24 +14,18 @@ jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    # Run in Playwright's image: browsers are pre-baked, so we skip the on-runner
+    # `playwright install`, which hangs fetching browser artifacts from the CDN.
+    # The tag must track @playwright/test in package.json (1.59.1).
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-          cache: pnpm
+      - run: corepack enable
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        # Chromium only (the sole browser these tests use). No --with-deps: the
-        # apt OS-deps step hangs on the runner, and ubuntu-latest already ships
-        # the libraries Chromium needs.
-        run: pnpm exec playwright install chromium
 
       - name: Run Playwright tests
         run: pnpm test:visual

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
+        # Chromium only (the sole browser these tests use). No --with-deps: the
+        # apt OS-deps step hangs on the runner, and ubuntu-latest already ships
+        # the libraries Chromium needs.
+        run: pnpm exec playwright install chromium
 
       - name: Run Playwright tests
         run: pnpm test:visual

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -15,32 +15,27 @@ jobs:
   update:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    # Run in Playwright's image: browsers are pre-baked, so we skip the on-runner
+    # `playwright install`, which hangs fetching browser artifacts from the CDN.
+    # The tag must track @playwright/test in package.json (1.59.1).
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-          cache: pnpm
+      - run: corepack enable
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        # Chromium only (the sole browser these tests use). No --with-deps: the
-        # apt OS-deps step hangs on the runner, and ubuntu-latest already ships
-        # the libraries Chromium needs.
-        run: pnpm exec playwright install chromium
 
       - name: Update snapshots
         run: pnpm test:visual:update
 
       - name: Commit updated snapshots
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add tests/visual.spec.ts-snapshots

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -31,7 +31,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
+        # Chromium only (the sole browser these tests use). No --with-deps: the
+        # apt OS-deps step hangs on the runner, and ubuntu-latest already ships
+        # the libraries Chromium needs.
+        run: pnpm exec playwright install chromium
 
       - name: Update snapshots
         run: pnpm test:visual:update

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig } from "astro/config";
 
 export default defineConfig({
   site: "https://www.ericminassian.com",
-  integrations: [sitemap()],
+  integrations: [sitemap({ filter: (page) => !page.includes("/auth/") })],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:visual:update": "playwright test --update-snapshots"
   },
   "dependencies": {
+    "@ericminassian/auth": "^0.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/newsreader": "^5.2.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ericminassian/auth':
+        specifier: ^0.3.0
+        version: 0.3.0
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
@@ -145,6 +148,21 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@ericminassian/auth@0.3.0':
+    resolution: {integrity: sha512-WQc/a7TpYBh/PvIswmEuvDPDe2ftR5jc8Zlbgfv4D13Xq66MKiiIJ0gk/NSPwbtqxEAx3NjGR/ItJzH+dvMHOQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      express: '>=5'
+      hono: '>=4'
+      react: '>=18'
+    peerDependenciesMeta:
+      express:
+        optional: true
+      hono:
+        optional: true
+      react:
+        optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -1381,6 +1399,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -2410,6 +2431,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@ericminassian/auth@0.3.0':
+    dependencies:
+      jose: 6.2.3
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -3479,6 +3504,8 @@ snapshots:
       is-inside-container: 1.0.0
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-yaml@4.1.1:
     dependencies:

--- a/src/components/AuthStatus.astro
+++ b/src/components/AuthStatus.astro
@@ -1,0 +1,88 @@
+---
+// Footer auth control: shows "Sign in", or the signed-in user's email with a
+// "Sign out" action. Renders a neutral (hidden) placeholder on the server and
+// hydrates in the browser — auth state lives in sessionStorage, so it is only
+// known client-side.
+---
+
+<div data-auth-status class="font-mono text-xs" hidden>
+  <button type="button" data-auth-signin class="auth-action" hidden>Sign in</button>
+  <span data-auth-user class="inline-flex items-center gap-2" hidden>
+    <span
+      data-auth-email
+      class="text-[var(--color-muted)] dark:text-[var(--color-muted-dark)]"></span>
+    <button type="button" data-auth-signout class="auth-action">Sign out</button>
+  </span>
+</div>
+
+<script>
+  import { getAuthClient } from "../lib/auth";
+  import type { AuthState } from "@ericminassian/auth/client";
+
+  const root = document.querySelector<HTMLElement>("[data-auth-status]");
+  if (root) {
+    const signInBtn = root.querySelector<HTMLButtonElement>("[data-auth-signin]");
+    const userEl = root.querySelector<HTMLElement>("[data-auth-user]");
+    const emailEl = root.querySelector<HTMLElement>("[data-auth-email]");
+    const signOutBtn = root.querySelector<HTMLButtonElement>("[data-auth-signout]");
+    const auth = getAuthClient();
+
+    function render(state: AuthState): void {
+      if (!root) return;
+      const loading = state.status === "loading";
+      const authed = state.status === "authenticated";
+      if (signInBtn) signInBtn.hidden = loading || authed;
+      if (userEl) userEl.hidden = !authed;
+      if (state.status === "authenticated" && emailEl) {
+        emailEl.textContent = state.user.email ?? "Signed in";
+      }
+      root.hidden = loading;
+    }
+
+    signInBtn?.addEventListener("click", () => {
+      void auth.signInWithRedirect();
+    });
+    signOutBtn?.addEventListener("click", () => {
+      void auth.signOut({
+        postLogoutRedirectUri: new URL("/", window.location.origin).href,
+      });
+    });
+
+    render(auth.getState());
+    auth.onStateChange(render);
+
+    // Pick up an existing auth.ericminassian.com session automatically (silent
+    // SSO via a hidden iframe). Top-level only, so it never recurses inside the
+    // callback iframe, and only when not already signed in. No-op on localhost
+    // (the cross-site session cookie isn't sent to the iframe).
+    if (window.self === window.top && auth.getState().status !== "authenticated") {
+      void auth.signInSilently();
+    }
+  }
+</script>
+
+<style>
+  .auth-action {
+    background: transparent;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: var(--color-muted);
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-color: var(--color-muted);
+    text-underline-offset: 2px;
+  }
+  .auth-action:hover {
+    color: var(--color-text);
+    text-decoration-color: var(--color-text);
+  }
+  :global(.dark) .auth-action {
+    color: var(--color-muted-dark);
+    text-decoration-color: var(--color-muted-dark);
+  }
+  :global(.dark) .auth-action:hover {
+    color: var(--color-text-dark);
+    text-decoration-color: var(--color-text-dark);
+  }
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  /** OIDC client_id for this site. Defaults to "website" when unset. */
+  readonly PUBLIC_AUTH_CLIENT_ID?: string;
+  /** OIDC issuer override (e.g. a local auth stack). Defaults to the SDK's production issuer. */
+  readonly PUBLIC_AUTH_ISSUER?: string;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import AuthStatus from "../components/AuthStatus.astro";
 import ThemeToggle from "../components/ThemeToggle.astro";
 import { GA_ID, getThemeScript } from "../scripts/theme";
 import "../styles/globals.css";
@@ -245,6 +246,9 @@ const jsonLd = {
   </head>
 
   <body class:list={["mx-auto px-8", wide ? "max-w-[900px] py-8" : "max-w-[650px] py-16"]}>
+    <div class="fixed right-4 top-4 z-50">
+      <AuthStatus />
+    </div>
     <main class:list={["w-full", wide ? "" : "md:mt-16"]}>
       <slot />
     </main>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,30 @@
+import { createAuthClient, type AuthClient } from "@ericminassian/auth/client";
+
+/** Path of the OIDC redirect callback page (see src/pages/auth/callback.astro). */
+export const CALLBACK_PATH = "/auth/callback";
+
+let client: AuthClient | undefined;
+
+/**
+ * The site's OIDC client against auth.ericminassian.com, created lazily on
+ * first use.
+ *
+ * Browser-only: the redirect URI is derived from the current origin, so the
+ * same build works locally (http://localhost:4321) and in production
+ * (https://www.ericminassian.com). Both callback URLs must be registered as
+ * `redirect_uris` for this client in the auth provider's config/clients.json.
+ */
+export function getAuthClient(): AuthClient {
+  if (typeof window === "undefined") {
+    throw new Error("getAuthClient() must be called in the browser");
+  }
+  if (!client) {
+    const issuer = import.meta.env.PUBLIC_AUTH_ISSUER;
+    client = createAuthClient({
+      clientId: import.meta.env.PUBLIC_AUTH_CLIENT_ID ?? "website",
+      redirectUri: new URL(CALLBACK_PATH, window.location.origin).href,
+      ...(issuer ? { issuer } : {}),
+    });
+  }
+  return client;
+}

--- a/src/pages/auth/callback.astro
+++ b/src/pages/auth/callback.astro
@@ -1,0 +1,34 @@
+---
+// OIDC redirect callback. Deliberately NOT wrapped in Layout: in the silent-SSO
+// flow this page loads inside a hidden iframe, so it must not pull in AuthStatus
+// (which would recurse into another silent attempt) or analytics. handleCallback()
+// relays the result to the opener when framed, or completes the code exchange and
+// returns where to go at top level.
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Signing in…</title>
+  </head>
+  <body>
+    <p>Signing you in…</p>
+
+    <script>
+      import { getAuthClient } from "../../lib/auth";
+
+      (async () => {
+        try {
+          const result = await getAuthClient().handleCallback();
+          // null => handled inside a silent-auth iframe; do nothing further.
+          if (result) window.location.replace(result.returnTo ?? "/");
+        } catch (error) {
+          console.error("Sign-in callback failed", error);
+          window.location.replace("/");
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -1,6 +1,14 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("visual regression", () => {
+  test.beforeEach(async ({ page }) => {
+    // AuthStatus attempts silent SSO on load (a hidden prompt=none iframe to the
+    // live auth server). That makes screenshots slow and non-deterministic — and
+    // hung CI — so block all auth-server traffic. Silent SSO then no-ops and the
+    // page renders the stable unauthenticated UI ("Sign in").
+    await page.route(/auth\.ericminassian\.com/, (route) => route.abort());
+  });
+
   test("home page - light", async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem("theme", "light");


### PR DESCRIPTION
## What

Integrates sign-in via `@ericminassian/auth` (OIDC authorization code + PKCE, fully client-side — suits this static site).

- `src/lib/auth.ts`: lazy singleton client; redirect URI derived from the current origin so one build works on localhost and www. `client_id: "website"`, with `PUBLIC_AUTH_CLIENT_ID` / `PUBLIC_AUTH_ISSUER` overrides.
- `AuthStatus` component (fixed top-right): "Sign in", or the signed-in email + "Sign out". Attempts **silent SSO** on load (hidden `prompt=none` iframe via the SDK's `signInSilently()`), top-level only so it never recurses inside the callback iframe.
- `src/pages/auth/callback.astro`: minimal standalone callback page using `handleCallback()` — relays to the opener inside the silent iframe, completes the code exchange at top level.
- Exclude `/auth/*` from the sitemap; type the `PUBLIC_AUTH_*` env vars.

Silent SSO is same-site only, so auto-sign-in activates on `www`, not localhost.

## CI fixes (were already broken on main)

The Playwright workflow has been timing out on every PR for ~2 weeks: `playwright install` downloads Chrome to 100% then hangs fetching the next browser artifact from the CDN until the 10-min job timeout. Fixed by running the jobs in `mcr.microsoft.com/playwright:v1.59.1-noble` (browsers pre-baked) via corepack, dropping the on-runner install. Also: the visual tests now block auth-server traffic so silent SSO can't make screenshots slow/non-deterministic.

## Test

- `astro check`, `oxlint`, `oxfmt`, `astro build` clean locally.
- Visual suite passes (10/10) in CI; the auth widget is within the existing `maxDiffPixelRatio` tolerance, so no snapshot churn.

Deploys to `www` on merge (GitHub Pages). After that: sign in once → revisits auto-sign-in silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)