### PR TITLE
chore: bump GitHub Actions and add Lighthouse diagnostics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install, build, and upload your site
         uses: withastro/action@v6
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,11 +15,11 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
           cache: pnpm
@@ -32,3 +32,11 @@ jobs:
 
       - name: Run Lighthouse
         run: pnpm test:lighthouse
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-reports
+          path: lighthouse-reports/
+          if-no-files-found: ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,11 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
           cache: pnpm

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,11 +15,11 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
           cache: pnpm

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -16,13 +16,13 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.branch }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
           cache: pnpm

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pnpm-debug.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# lighthouse
+/lighthouse-reports/

--- a/scripts/run-lighthouse.mjs
+++ b/scripts/run-lighthouse.mjs
@@ -1,12 +1,28 @@
 import { spawn } from "node:child_process";
 import { createReadStream } from "node:fs";
-import { readFile, stat } from "node:fs/promises";
+import { mkdir, readFile, stat } from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
 
 const DIST_DIR = path.resolve("dist");
+const REPORT_DIR = path.resolve("lighthouse-reports");
 const LIGHTHOUSE_FLAGS = ["--headless=new", "--no-sandbox"];
 const REQUIRED_SCORE = 1;
+const PERF_DIAGNOSTIC_AUDITS = [
+  "first-contentful-paint",
+  "largest-contentful-paint",
+  "speed-index",
+  "total-blocking-time",
+  "cumulative-layout-shift",
+  "interactive",
+  "max-potential-fid",
+  "server-response-time",
+  "render-blocking-resources",
+  "unused-javascript",
+  "unused-css-rules",
+  "uses-text-compression",
+  "uses-responsive-images",
+];
 
 const MIME_TYPES = {
   ".css": "text/css; charset=utf-8",
@@ -134,8 +150,41 @@ async function startStaticServer() {
   };
 }
 
+function formatAudit(audit) {
+  const score = audit.score === null ? "n/a" : audit.score.toFixed(2);
+  const value = audit.displayValue ? ` (${audit.displayValue})` : "";
+  return `    - ${audit.id}: score=${score}${value}`;
+}
+
+function logPerformanceDiagnostics(name, report) {
+  const audits = report.audits ?? {};
+  const lines = [`  ${name} performance audits:`];
+
+  for (const id of PERF_DIAGNOSTIC_AUDITS) {
+    const audit = audits[id];
+    if (audit) {
+      lines.push(formatAudit(audit));
+    }
+  }
+
+  const failing = Object.values(audits).filter(
+    (audit) =>
+      typeof audit.score === "number" &&
+      audit.score < 1 &&
+      !PERF_DIAGNOSTIC_AUDITS.includes(audit.id),
+  );
+  if (failing.length > 0) {
+    lines.push("  other audits with score < 1:");
+    for (const audit of failing) {
+      lines.push(formatAudit(audit));
+    }
+  }
+
+  console.log(lines.join("\n"));
+}
+
 async function runSingleLighthouse(baseUrl, { name, extraArgs }) {
-  const outputPath = `./tmp-lighthouse-${name}.json`;
+  const outputPath = path.join(REPORT_DIR, name);
 
   await run("npx", [
     "--yes",
@@ -144,11 +193,12 @@ async function runSingleLighthouse(baseUrl, { name, extraArgs }) {
     "--quiet",
     `--output-path=${outputPath}`,
     "--output=json",
+    "--output=html",
     `--chrome-flags=${LIGHTHOUSE_FLAGS.join(" ")}`,
     ...extraArgs,
   ]);
 
-  const report = JSON.parse(await readFile(outputPath, "utf8"));
+  const report = JSON.parse(await readFile(`${outputPath}.report.json`, "utf8"));
   const categories = report.categories;
   const scores = {
     performance: categories.performance.score,
@@ -157,26 +207,39 @@ async function runSingleLighthouse(baseUrl, { name, extraArgs }) {
     seo: categories.seo.score,
   };
 
-  for (const [category, score] of Object.entries(scores)) {
-    if (score < REQUIRED_SCORE) {
-      throw new Error(
-        `${name} ${category} score was ${roundedScore(score)}; required ${roundedScore(REQUIRED_SCORE)}`,
-      );
-    }
-  }
-
   console.log(
     `${name}:`,
     Object.entries(scores)
       .map(([category, score]) => `${category}=${roundedScore(score)}`)
       .join(" "),
   );
+
+  for (const [category, score] of Object.entries(scores)) {
+    if (score < REQUIRED_SCORE) {
+      if (category === "performance") {
+        logPerformanceDiagnostics(name, report);
+      }
+      throw new Error(
+        `${name} ${category} score was ${roundedScore(score)}; required ${roundedScore(REQUIRED_SCORE)}`,
+      );
+    }
+  }
 }
 
+await mkdir(REPORT_DIR, { recursive: true });
 const server = await startStaticServer();
 
 try {
-  await Promise.all(runs.map((runConfig) => runSingleLighthouse(server.url, runConfig)));
+  const results = await Promise.allSettled(
+    runs.map((runConfig) => runSingleLighthouse(server.url, runConfig)),
+  );
+  const failures = results.filter((result) => result.status === "rejected");
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(failure.reason);
+    }
+    throw new Error(`${failures.length} lighthouse run(s) failed`);
+  }
 } finally {
   await server.close();
 }


### PR DESCRIPTION
## Why

#247 already landed the Astro 7 / notes-removal update. Most open PRs are now obsolete npm bumps. The remaining valid work is consolidated here so those PRs can close.

## What

- Bump `actions/checkout` 6 → 7, `actions/setup-node` 6 → 7, and `pnpm/action-setup` 5 → 6 across all workflows
- Port Lighthouse diagnostics from #217: write JSON+HTML reports, upload them as an artifact, log failing audits, and use `Promise.allSettled` so a mobile failure still produces the desktop report

## Supersedes

- #246 `actions/setup-node` 6 → 7
- #245 `actions/checkout` 6 → 7
- #186 `pnpm/action-setup` 5 → 6
- #217 Lighthouse report artifacts and diagnostics

## Already landed in #247 (closing separately)

- #244 oxfmt, #243 typography, #242/#241 tailwind, #240 astro 6, #239 oxlint, #238 @types/node, #232 sitemap, #221 playwright, #202 @astrojs/check

#237 (auth SSO) is a feature, not an update, and targets the pre-simplification site. Closing as stale.